### PR TITLE
Fixed 5 issues of type: PYTHON_F401 throughout 5 files in repo.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+from setuptools import setup
 import os
 from glob import glob
 

--- a/spykesim/setup.py
+++ b/spykesim/setup.py
@@ -13,7 +13,6 @@
 ##    extra_link_args=['-fopenmp'],
 ##)
 from distutils.core import setup
-from Cython.Build import cythonize
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import Cython.Compiler.Options

--- a/tests/test_editsim.py
+++ b/tests/test_editsim.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 from scipy import sparse
-from nose.tools import ok_, eq_
+from nose.tools import eq_
 from ..spykesim import editsim
 
 def genpoisson_spiketrain(rate, dt, duration):

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
-import os
-from nose.tools import ok_, eq_
+from nose.tools import eq_
 from ..spykesim import minhash
 import numpy as np
 from scipy.sparse import csc_matrix


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        